### PR TITLE
Create resize script for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .vscode
+.DS_Store
 
 # function zip folder
 *.zip
@@ -7,3 +8,6 @@
 # lambda folder
 lambda/node_modules
 lambda/package-lock.json
+
+# local testing
+lambda/local-resize/images

--- a/lambda/local-resize/index.js
+++ b/lambda/local-resize/index.js
@@ -1,0 +1,96 @@
+// native node modules
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+
+// yargs cmd line helpers
+const yargs = require('yargs/yargs')
+const { hideBin } = require('yargs/helpers')
+const argv = yargs(hideBin(process.argv)).argv
+
+// lambda functions
+const ImageLib = require('../util/ImageLib');
+const QueryParser = require('../util/QueryParser');
+const ALLOW_IMAGE_EXT = ['jpg', 'png', 'jpeg', 'webp'];
+
+// script args
+const defaultImgs = {
+    landscape: 'https://d113q3lewv5kc2.cloudfront.net/images/Charleston-IN-Steadfast.jpg',
+    portrait: 'https://d113q3lewv5kc2.cloudfront.net/images/IMG_1682_(1).jpg'
+}
+const imgUrl = argv.imgUrl || defaultImgs[argv.orientation] || defaultImgs.portrait;
+const format = argv.format || '@600w_400h.webp';
+
+// global vars
+const subdir = `${__dirname}/images`;
+const imgProperties = (() => {
+    const splitUrl = imgUrl.split('/');
+    const lastEl = splitUrl[splitUrl.length - 1];
+    const extension = ALLOW_IMAGE_EXT.find((ext) => lastEl.includes(ext));
+    const indexEnd = lastEl.indexOf('.');
+    const name = lastEl.substring(0, indexEnd);
+
+    return {
+        name,
+        extension,
+        fullName: `${name}.${extension}`
+    }
+})();
+
+// run resizer
+resizeImage(imgUrl);
+
+async function resizeImage(imgUrl) {
+    // dowload/read original image
+    const imgPath = await downloadImage(imgUrl);
+    const imgBuffer = fs.readFileSync(imgPath);
+
+    // resize image
+    console.log('Resizing image');
+    console.log(`isBuffer: ${imgBuffer instanceof Buffer}`);
+    const sanitizedUri = (() => {
+        // removes any url garbage after file extension
+        const indexEnd = imgUrl.indexOf(imgProperties.fullName) + imgProperties.fullName.length;
+        return imgUrl.substring(0, indexEnd) + format;
+    })();
+    const { targetFormatExt, filterMap } = QueryParser.parseUri(sanitizedUri);
+    const resizedBuffer = await ImageLib.adjustImage(imgBuffer, targetFormatExt, filterMap);
+
+    // save resized image under new name
+    let resizedName = `${imgProperties.name}${format}`;
+    if(!resizedName.includes('.')) {
+        resizedName += `.${imgProperties.extension}`;
+    }
+    const resizedPath = path.resolve(subdir, resizedName);
+    fs.writeFileSync(resizedPath, resizedBuffer);
+    console.log('Resize Complete');
+}
+
+async function downloadImage (imgUrl) {
+    return new Promise((resolve) => {
+        const savePath = path.resolve(subdir, imgProperties.fullName);
+
+        // skip download if file already exists
+        if(fs.existsSync(savePath)) {
+            console.log('Image already downloaded')
+            return resolve(savePath);
+        }
+
+        // create /images subdir if needed
+        if(!fs.existsSync(subdir)) {
+            fs.mkdirSync(subdir);
+        }
+
+        // download file
+        console.log('Downloading image');
+        const file = fs.createWriteStream(savePath);
+        https.get(imgUrl, (response) => {
+            response.pipe(file);
+            file.on("finish", () => {
+                console.log("Download Complete");
+                file.close();
+                return resolve(savePath);
+            });
+        });
+    });
+};

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "aws-sdk": "2.631.0",
-    "sharp": "^0.25.4"
+    "sharp": "^0.25.4",
+    "yargs": "^17.5.1"
   }
 }


### PR DESCRIPTION
Run `cd lambda && npm i`. Then you can use this local dev script to run `node local-resize [imgUrl | orientation] [format]`.

- imgUrl: a url to any image. Defaults to the `defaultImgs.portrait`, since that's been the image we've encountered rotation issues with
- defaultImg: portrait | landscape (let's you pick a default image in script file if imgUrl isn't provided)
- format: resize/webp format. Default is `@600w_400h.webp`